### PR TITLE
improve choosing time/date and use this value for grafana dashboard

### DIFF
--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -1,4 +1,13 @@
-export default function Header({onDiscussSimulation, onReinforcementLearning}: {onDiscussSimulation?: () => void, onReinforcementLearning?: () => void} = {}) {
+export default function Header({
+    onDiscussSimulation,
+    onReinforcementLearning,
+    grafanaResultsHref = '/grafana',
+}: {
+    onDiscussSimulation?: () => void;
+    onReinforcementLearning?: () => void;
+    // World time range for Grafana, e.g. `/grafana/?from=...&to=...`
+    grafanaResultsHref?: string;
+} = {}) {
     const header_classes = "p-2 m-1 text-xl rounded-md hover:bg-gray-300 cursor-pointer";
     
     return (
@@ -6,7 +15,7 @@ export default function Header({onDiscussSimulation, onReinforcementLearning}: {
             <a href="/"><img src="assume_logo.png" alt="ASSUME Logo" className="w-20" /></a>
             <nav>
                 <ul>
-                    <a className={header_classes} href="/grafana">Results</a>
+                    <a className={header_classes} href={grafanaResultsHref}>Results</a>
                     <button
                         type="button" 
                         className={header_classes}

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -35,6 +35,7 @@ import Sidebar from "./ui/Sidebar.tsx";
 import DiscussSimulationChat from "./ui/DiscussSimulationChat.tsx";
 import type {EditSidebarData, EditSidebarProps} from "./ui/SidebarComponents/NodeEditSidebar.tsx";
 import {sendData, type DataResponse} from "./sendData.ts";
+import {buildGrafanaResultsHref} from "./utils.ts";
 import {Alert, type AlertColor, Snackbar} from "@mui/material";
 
 const nodeTypes = {
@@ -125,6 +126,12 @@ export default function Home() {
     const [showRlComingSoon, setShowRlComingSoon] = useState(false);
 
     const worldJson = useMemo(() => JSON.stringify({nodes: nodes, edges: edges}), [nodes, edges]);
+
+    const grafanaResultsHref = useMemo(() => {
+        const world = nodes.find((n) => n.type === 'world');
+        if (!world?.data) return '/grafana';
+        return buildGrafanaResultsHref(world.data.start, world.data.end);
+    }, [nodes]);
 
     const updateValue = useCallback((id: string, data: EditSidebarData, isEdge: boolean) => {
         type T = Node<EditSidebarData> | Edge<EditSidebarData>;
@@ -340,6 +347,7 @@ export default function Home() {
             />
             <div className="flex grow flex-col select-none">
                 <Header
+                    grafanaResultsHref={grafanaResultsHref}
                     onDiscussSimulation={() => setShowDiscuss(true)}
                     onReinforcementLearning={() => setShowRlComingSoon(true)}
                 />

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,52 @@
 import type {EditSidebarData} from "./ui/SidebarComponents/NodeEditSidebar.tsx";
 
+/** Parse world `datetime-local` strings as local wall time. */
+export function parseWorldDatetimeLocal(value: unknown): Date | null {
+    if (typeof value !== 'string') return null;
+    const s = value.trim();
+    if (!s) return null;
+    const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(s);
+    if (dateOnly) {
+        const d = new Date(
+            Number(dateOnly[1]),
+            Number(dateOnly[2]) - 1,
+            Number(dateOnly[3]),
+            0,
+            0,
+            0,
+            0
+        );
+        return Number.isNaN(d.getTime()) ? null : d;
+    }
+    const m = /^(\d{4})-(\d{2})-(\d{2})[T\s](\d{1,2}):(\d{2})/.exec(s);
+    if (!m) return null;
+    const d = new Date(
+        Number(m[1]),
+        Number(m[2]) - 1,
+        Number(m[3]),
+        Number(m[4]),
+        Number(m[5]),
+        0,
+        0
+    );
+    return Number.isNaN(d.getTime()) ? null : d;
+}
+
+/**
+ * `/grafana` proxy URL with `from` / `to` as UTC ISO strings (Grafana-style), from world start/end.
+ * Falls back to `/grafana` if either value is missing or invalid.
+ */
+export function buildGrafanaResultsHref(start: unknown, end: unknown): string {
+    const fromDate = parseWorldDatetimeLocal(start);
+    const toDate = parseWorldDatetimeLocal(end);
+    if (!fromDate || !toDate) return '/grafana';
+    const params = new URLSearchParams({
+        from: fromDate.toISOString(),
+        to: toDate.toISOString(),
+    });
+    return `/grafana/?${params.toString()}`;
+}
+
 export function handleChange(id: string, data: EditSidebarData, updateNodeValue: (id: string, data: EditSidebarData, isEdge: boolean) => void, isEdge: boolean = false) {
     return (key: string) => (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
         const d = { ...data }


### PR DESCRIPTION
Usability was cumbersome as Firefox does not fully support the [input-datetime](https://caniuse.com/#feat=input-datetime) - the clock is not available.
Chrome also just sets the current time without a popup.

Therefore, a default start and end time and date is set.

This date is then used for the grafana url as url params. This helps to directly jump to the relevant part of the dashboard.

fixes #11