### PR TITLE
added: create note on edge drop

### DIFF
--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -9,6 +9,7 @@ import {
     Controls,
     type Edge,
     type EdgeChange,
+    type FinalConnectionState,
     type Node,
     type NodeChange,
     type NodeSelectionChange,
@@ -232,6 +233,66 @@ export default function Home() {
         [setEdges],
     );
 
+    const onConnectEnd = useCallback(
+        (event: MouseEvent | TouchEvent, connectionState: FinalConnectionState) => {
+            // if normal onConnect, fromHandle missing, starting not from 'source' or missing handle id: stop
+            if (connectionState.isValid || !connectionState.fromHandle) return;
+            if (connectionState.fromHandle.type !== 'source' || !connectionState.fromHandle.id) return;
+
+            // Logic to get correct Node type and Handle id
+            const sourceNodeId = connectionState.fromHandle.nodeId;
+            const sourceHandleId = connectionState.fromHandle.id;
+
+            // NOTE: this only works if no '_' in handle except at end!
+            // New node type from source handle prefix (e.g., "market_handle" → "market")
+            const newNodeType = sourceHandleId.split('_')[0];
+            // Target handle = source node type prefix + "_handle"
+            const sourcePrefix = sourceNodeId.split('_')[0];
+            const targetHandleId = `${sourcePrefix}_handle`;
+
+            // Gets position independent of mouse and touchscreen
+            const clientX = 'changedTouches' in event
+                ? event.changedTouches[0].clientX
+                : event.clientX;
+            const clientY = 'changedTouches' in event
+                ? event.changedTouches[0].clientY
+                : event.clientY;
+
+            // create new Node at canvas coords corresponding to mouse postion
+            const newNodeId = getId(newNodeType);
+            const newNode: Node<EditSidebarData> = {
+                id: newNodeId,
+                type: newNodeType,
+                position: screenToFlowPosition({x: clientX, y: clientY}),
+                data: {
+                    name: getName(newNodeType),
+                    errorField: '',
+                    errorMessage: '',
+                },
+            };
+
+            // Build edge like in onConnect
+            const newEdge: Edge<EditSidebarData> = {
+                id: `${sourceNodeId}#${sourceHandleId}#${newNodeId}#${targetHandleId}`,
+                source: sourceNodeId,
+                sourceHandle: sourceHandleId,
+                target: newNodeId,
+                targetHandle: targetHandleId,
+                type: 'default',
+                data: {name: 'a connection', errorField: '', errorMessage: ''},
+            };
+
+            // Special edge treatment if unit to market
+            if (sourceNodeId.startsWith('unit') && newNodeId.startsWith('market')) {
+                newEdge.type = 'unit-market';
+            }
+
+            setNodes((nds) => nds.concat(newNode));
+            setEdges((eds) => eds.concat(newEdge));
+        },
+        [screenToFlowPosition, setNodes, setEdges],
+    );
+
     const updateForecast = useCallback((type: keyof Forecast, value: string | null) => {
         const tmp = structuredClone(forecast)
         tmp[type] = value
@@ -397,6 +458,7 @@ export default function Home() {
                         onNodesChange={onNodesChange}
                         onEdgesChange={onEdgesChange}
                         onConnect={onConnect}
+                        onConnectEnd={onConnectEnd}
                         onDragOver={onDragOver}
                         isValidConnection={isValidConnectionCb}
                         onDrop={onDrop}

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -197,7 +197,7 @@ export default function Home() {
         [edges, setEdges, setNodeData],
     );
 
-    const isValidConnectionCb = useCallback(
+    const isValidConnection = useCallback(
         (connection: Connection | Edge) => {
             const sameFromHandles =
                 connection.targetHandle?.split("_")[0] === connection.source?.split("_")[0];
@@ -236,7 +236,7 @@ export default function Home() {
     const onConnectEnd = useCallback(
         (event: MouseEvent | TouchEvent, connectionState: FinalConnectionState) => {
             // if normal onConnect, fromHandle missing, starting not from 'source' or missing handle id: stop
-            if (connectionState.isValid || !connectionState.fromHandle) return;
+            if (connectionState.isValid != null || !connectionState.fromHandle) return;
             if (connectionState.fromHandle.type !== 'source' || !connectionState.fromHandle.id) return;
 
             // Logic to get correct Node type and Handle id
@@ -460,7 +460,7 @@ export default function Home() {
                         onConnect={onConnect}
                         onConnectEnd={onConnectEnd}
                         onDragOver={onDragOver}
-                        isValidConnection={isValidConnectionCb}
+                        isValidConnection={isValidConnection}
                         onDrop={onDrop}
                         edgeTypes={edgeTypes}
                         fitView

--- a/src/ui/Nodes.tsx
+++ b/src/ui/Nodes.tsx
@@ -20,6 +20,7 @@ export function WorldNode({data, isConnectable, selected}: NodeProps<Node<EditSi
             <Handle
                 id="marketProvider_handle"
                 type="source"
+                className="!bg-sky-400"
                 position={Position.Bottom}
                 isConnectable={isConnectable}
                 style={{left: '25%'}}
@@ -28,6 +29,7 @@ export function WorldNode({data, isConnectable, selected}: NodeProps<Node<EditSi
             <Handle
                 id="unitOperator_handle"
                 type="source"
+                className="!bg-fuchsia-400"
                 position={Position.Bottom}
                 isConnectable={isConnectable}
                 style={{left: '75%'}}
@@ -44,6 +46,7 @@ export function MarketNode({data, isConnectable, selected}: NodeProps<Node<EditS
             <Handle
                 id="marketProvider_handle"
                 type="target"
+                className="!bg-teal-400"
                 position={Position.Top}
                 isConnectable={isConnectable && connections.length == 0}
                 title="Connect from world (market providers)"
@@ -59,6 +62,7 @@ export function MarketNode({data, isConnectable, selected}: NodeProps<Node<EditS
             <Handle
                 id="marketProduct_handle"
                 type="source"
+                className="!bg-lime-400"
                 position={Position.Bottom}
                 isConnectable={isConnectable}
             />
@@ -73,6 +77,7 @@ export function MarketProviderNode({data, isConnectable, selected}: NodeProps<No
             <Handle
                 id="world_handle"
                 type="target"
+                className="!bg-sky-400"
                 position={Position.Top}
                 isConnectable={isConnectable && connections.length == 0}
                 title="Connect from world"
@@ -82,6 +87,7 @@ export function MarketProviderNode({data, isConnectable, selected}: NodeProps<No
             <Handle
                 id="market_handle"
                 type="source"
+                className="!bg-teal-400"
                 position={Position.Bottom}
                 isConnectable={isConnectable}
                 title="Connect to markets"
@@ -98,6 +104,7 @@ export function UnitNode({data, isConnectable, selected}: NodeProps<Node<EditSid
             <Handle
                 id="unitOperator_handle"
                 type="target"
+                className="!bg-violet-400"
                 position={Position.Top}
                 isConnectable={isConnectable && connections.length == 0}
                 title="Connect from unit operator"
@@ -126,6 +133,7 @@ export function UnitOperatorNode({data, isConnectable, selected}: NodeProps<Node
         <>
             <Handle
                 id="world_handle"
+                className="!bg-fuchsia-400"
                 type="target"
                 position={Position.Top}
                 isConnectable={isConnectable && connections.length == 0}
@@ -135,6 +143,7 @@ export function UnitOperatorNode({data, isConnectable, selected}: NodeProps<Node
             <Handle
                 id="unit_handle"
                 type="source"
+                className="!bg-violet-400"
                 position={Position.Bottom}
                 isConnectable={isConnectable}
                 title="Connect to units"
@@ -151,6 +160,7 @@ export function MarketProductNode({data, isConnectable, selected}: NodeProps<Nod
                 id="market_handle"
                 type="target"
                 position={Position.Top}
+                className="!bg-lime-400"
                 isConnectable={isConnectable && connections.length == 0}
                 title="Connect from market"
             />


### PR DESCRIPTION
Added functionality that creates nodes automatically if an edge is dropped on the canvas.

Closes #8 

Should we allow to build a source node from a target and only exclude the "world" node?